### PR TITLE
Updated NuSpec, README, and exposed factory for UploadProgressArgs

### DIFF
--- a/Allos.Amazon.Sdk.sln
+++ b/Allos.Amazon.Sdk.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		License.txt = License.txt
 		README.md = README.md
 		Allos.Amazon.Sdk.sln = Allos.Amazon.Sdk.sln
+		Allos.Amazon.Sdk\Allos.Amazon.Sdk.csproj = Allos.Amazon.Sdk\Allos.Amazon.Sdk.csproj
+		Allos.Amazon.Sdk.Tests\Allos.Amazon.Sdk.Tests.csproj = Allos.Amazon.Sdk.Tests\Allos.Amazon.Sdk.Tests.csproj
 	EndProjectSection
 EndProject
 Global

--- a/Allos.Amazon.Sdk/Allos.Amazon.Sdk.csproj
+++ b/Allos.Amazon.Sdk/Allos.Amazon.Sdk.csproj
@@ -6,23 +6,54 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>3.7.99.0</Version>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Amazon.Extensions.S3.Encryption" Version="[2.1.0, 3.0.0)" />
+        <PackageReference Include="AWSSDK.S3" Version="[3.7.400, 4.0.0)" />
+        <PackageReference Include="Serilog" Version="[4.0.0, 5.0.0)" />
+    </ItemGroup>
+
+    <PropertyGroup> <!-- NuGet Package [All Build Configurations] -->
+        <Deterministic>true</Deterministic> <!-- deterministic builds (affects `.nuspec`) -->
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild> <!-- Generates `.nuspec` and packs `.nupkg` on build -->
+        <PackageOutputPath>$(SolutionDir)/publish</PackageOutputPath>
+        <IncludeSymbols>true</IncludeSymbols> <!-- Include Debug symbols / PDBs -->
+        <Owners>tonic.ai</Owners>
+        <Description>
+            A manually created forked subset of the official AWS SDK (from aws-sdk-net) limited to the S3 type 
+            Amazon.S3.Transfer.TransferUtility, required supporting types, and relevant tests
+        </Description>
+        <Copyright>© 2024 Tonic AI</Copyright>
+        <PackageLanguage>en-US</PackageLanguage>
+        <PackageReadmeFile>contentFiles/README.md</PackageReadmeFile>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/TonicAI/Allos.Amazon.Sdk</PackageProjectUrl>
+        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+        <Authors>Brian Bennewitz</Authors>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+      <DebugSymbols>true</DebugSymbols>
+      <Version>3.7.99.0-debug+build.0</Version>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
       <DebugSymbols>true</DebugSymbols>
+      <Version>3.7.99.0+build.0</Version>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Amazon.Extensions.S3.Encryption" Version="2.1.1" />
-      <PackageReference Include="AWSSDK.S3" Version="3.7.400.4" />
-      <PackageReference Include="Serilog" Version="4.0.1" />
+    <ItemGroup> <!-- NuGet Package content files to pack -->
+        <None Include="$(SolutionDir)README.md">
+            <Pack>true</Pack>
+            <PackagePath>contentFiles/README.md</PackagePath>
+        </None>
+        <None Include="$(SolutionDir)License.txt">
+            <Pack>true</Pack>
+            <PackagePath>contentFiles/License.txt</PackagePath>
+        </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/Allos.Amazon.Sdk/IUploadProgressArgsFactory.cs
+++ b/Allos.Amazon.Sdk/IUploadProgressArgsFactory.cs
@@ -1,0 +1,54 @@
+﻿using Allos.Amazon.Sdk.S3.Transfer;
+
+namespace Allos.Amazon.Sdk;
+
+public interface IUploadProgressArgsFactory
+{
+    static IUploadProgressArgsFactory Instance { get; set; } = new DefaultUploadProgressArgsFactory();
+    
+    UploadProgressArgs Create(ulong incrementTransferred, ulong transferred, ulong? total);
+    UploadProgressArgs Create(ulong incrementTransferred, ulong transferred, ulong? total, string filePath);
+    UploadProgressArgs Create(
+        ulong incrementTransferred,
+        ulong transferred,
+        ulong? total,
+        ulong compensationForRetry,
+        string? filePath
+    );
+    UploadProgressArgs Create(UploadProgressArgs argsWithoutCompensation, ulong compensationForRetry);
+}
+
+public class DefaultUploadProgressArgsFactory : IUploadProgressArgsFactory
+{
+    public UploadProgressArgs Create(ulong incrementTransferred, ulong transferred, ulong? total) =>
+        new UploadProgressArgs(
+            incrementTransferred,
+            transferred,
+            total
+        );
+
+    public UploadProgressArgs Create(ulong incrementTransferred, ulong transferred, ulong? total, string filePath) =>
+        new UploadProgressArgs(
+            incrementTransferred,
+            transferred,
+            total,
+            0,
+            filePath
+        );
+
+    public UploadProgressArgs Create(
+        ulong incrementTransferred, 
+        ulong transferred, 
+        ulong? total, 
+        ulong compensationForRetry,
+        string? filePath) =>
+        new UploadProgressArgs(
+            incrementTransferred, 
+            transferred, 
+            total,
+            compensationForRetry, 
+            filePath);
+
+    public UploadProgressArgs Create(UploadProgressArgs argsWithoutCompensation, ulong compensationForRetry) =>
+        new UploadProgressArgs(argsWithoutCompensation, compensationForRetry);
+}

--- a/Allos.Amazon.Sdk/S3/Transfer/AsyncTransferUtility.cs
+++ b/Allos.Amazon.Sdk/S3/Transfer/AsyncTransferUtility.cs
@@ -421,7 +421,7 @@ namespace Allos.Amazon.Sdk.S3.Transfer
                             cancellationToken)
                         .ConfigureAwait(false);
 
-                    var progressArgs = new UploadProgressArgs(
+                    var progressArgs = IUploadProgressArgsFactory.Instance.Create(
                         0,
                         metadata.ContentLength.ToUInt64(),
                         request.ContentLength,

--- a/Allos.Amazon.Sdk/S3/Transfer/Commands/MultipartUploadCommand.cs
+++ b/Allos.Amazon.Sdk/S3/Transfer/Commands/MultipartUploadCommand.cs
@@ -694,12 +694,13 @@ namespace Allos.Amazon.Sdk.S3.Transfer.Internal
                 ref _totalTransferredBytes, 
                 e.IncrementTransferred - e.CompensationForRetry);
 
-            var progressArgs = new UploadProgressArgs(
+            var progressArgs = IUploadProgressArgsFactory.Instance.Create(
                 e.IncrementTransferred, 
                 transferredBytes, 
                 _contentLength,
                 e.CompensationForRetry, 
                 _fileTransporterRequest.FilePath);
+            
             _fileTransporterRequest.OnRaiseProgressEvent(progressArgs);
         }
     }
@@ -748,7 +749,7 @@ namespace Allos.Amazon.Sdk.S3.Transfer.Internal
                 }
             }
 
-            var progressArgs = new UploadProgressArgs(e, compensationForRetry);
+            var progressArgs = IUploadProgressArgsFactory.Instance.Create(e, compensationForRetry);
             
             _callback(this, progressArgs);
 
@@ -767,7 +768,7 @@ namespace Allos.Amazon.Sdk.S3.Transfer.Internal
                 if (_totalIncrementTransferred >= _progressUpdateInterval ||
                     (_contentLength.HasValue && _totalBytesRead == _contentLength.Value))
                 {
-                    var uploadProgressArgs = new UploadProgressArgs(
+                    var uploadProgressArgs = IUploadProgressArgsFactory.Instance.Create(
                         _totalIncrementTransferred,
                         _totalBytesRead,
                         _contentLength,

--- a/Allos.Amazon.Sdk/S3/Transfer/Commands/SimpleUploadCommand.cs
+++ b/Allos.Amazon.Sdk/S3/Transfer/Commands/SimpleUploadCommand.cs
@@ -134,12 +134,13 @@ namespace Allos.Amazon.Sdk.S3.Transfer.Internal
 
         protected virtual void PutObjectProgressEventCallback(object? sender, UploadProgressArgs e)
         {
-            var progressArgs = new UploadProgressArgs(
+            var progressArgs = IUploadProgressArgsFactory.Instance.Create(
                 e.IncrementTransferred, 
                 e.TransferredBytes, 
                 e.TotalBytes, 
                 e.CompensationForRetry, 
-                _fileTransporterRequest.FilePath);
+                _fileTransporterRequest.FilePath
+                );
             
             _fileTransporterRequest.OnRaiseProgressEvent(progressArgs);
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Allos.Amazon.Sdk
 
-A manually created forked subset of the official `AWS SDK` (from [aws-sdk-net](https://github.com/aws/aws-sdk-net.git)) limited to the `S3` type `Amazon.S3.Transfer.TransferUtility`, required supporting types, and relevant tests
+A manually created forked subset of the official `AWS SDK` (from [aws-sdk-net](https://github.com/aws/aws-sdk-net.git)) limited to the `S3` type `Amazon.S3.Transfer.TransferUtility`, required supporting types, and relevant tests.  The parts that are forked retain a package reference dependency to the original AWS SDK but expose alternate implementations of the forked functionality.
 
 #### Approach used by this fork:
 
@@ -49,7 +49,7 @@ A manually created forked subset of the official `AWS SDK` (from [aws-sdk-net](h
 
   > **NOTE** the underlying `aws sdk` reference may not yet make use of these and in that case they fallback to those value types for internal calls to that SDK
 
-- change namespaces to match extracted subset functionality and containing solution
+- change namespaces to match extracted subset functionality as well as the containing solution
 
 - change logging to use `Serilog`
 
@@ -71,3 +71,28 @@ The tests use the `AWS` credentials file to authenticate with `S3`
 In the definition for `Allos.Amazon.Sdk.Tests.IntegrationTests.Tests.TestBase` on which the property `TestAwsCredentialsProfileName` should be set to a profile name that exists in the local credential file. 
 
 > NOTE a default could also be hardcoded in the private field `_testAwsCredentialsProfileName`
+
+#### Progress Reporting Patchwork
+
+The original `Amazon.S3.Transfer.TransferUtility` would never fire `Amazon.Runtime.Internal.IAmazonWebServiceRequest.StreamUploadProgressCallback` events when uploading a `Stream` where one or more of the following was true:
+
+- `Stream.CanSeek` == `false`
+- `Stream.Length` would `throw`
+
+This limitation has been addressed by including one ore more additional types and patching some of the original type implementations as follows:
+
+- [**Forked, Patched**] `EventStream` 
+  - Forked an additional type `EventStream` and enhanced the `OnRead` event it publishes
+- [**Patched**] `SimpleUploadCommand`
+  - Patched the construction of `PutObjectRequest` to attach a `ProgressHandler` along with an `EventStream`
+  - Disconnected the existing event registration to `StreamUploadProgressCallback`
+  - Registered a handler on `ProgressHandler` that receives an enhanced implementation of `UploadProgressArgs` that removes the above limitations on this code path
+- [**Patched**] `MultipartUploadCommand`
+  - Patched the construction of `UploadPartRequest` to attach a `ProgressHandler` along with an `EventStream`
+  - Disconnected the existing event registration to `StreamUploadProgressCallback`
+  - Registered a handler on `ProgressHandler` that receives an enhanced implementation of `UploadProgressArgs` that removes the above limitations on this code path
+- [**Patched**] `**TransferUtility`
+  - Patched `UploadAsync` to handle a new edge case specific to `MultipartUploadCommand` and `Stream` instances that were previously subject to the above limitations
+
+The combination of these patches yields progress update events without limitations.
+


### PR DESCRIPTION
Updated NuSpec, README, and exposed factory for UploadProgressArgs
- Exposed `IUploadProgressArgsFactory` to allow for custom implementations of `UploadProgressArgs`
- Fixed `.nuspec` generation to support version ranges
- Added additional metadata to `.nuspec`
- Added `README.md` and `License.txt` to output `.nupkg`
- Updated `README.md` with patchwork details